### PR TITLE
feat: Modal component

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -12,13 +12,18 @@ export default async function Layout({
 }) {
   const role = await checkUserRole();
   return (
-    <main className="relative w-full flex flex-col sm:flex-row h-screen overflow-y-hidden">
-      <Sidebar />
+    <>
+      <div id="dialogs" />
+      <main className="relative w-full flex flex-col sm:flex-row h-screen overflow-y-hidden">
+        <Sidebar />
 
-      <div className="w-full flex flex-col h-full bg-white">
-        <Header />
-        {role === "admin" ? admin : user}
-      </div>
-    </main>
+        <div className="w-full flex flex-col h-full bg-white">
+          <Header />
+          <section className="h-full w-full overflow-auto">
+            {role === "admin" ? admin : user}
+          </section>
+        </div>
+      </main>
+    </>
   );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,7 +3,7 @@ import { signOut } from "next-auth/react";
 import { MouseEventHandler, useRef, useState } from "react";
 import { UserIcon } from "./icons/UserIcon";
 import Link from "next/link";
-import useClickOutside from "@/hooks/useClickOutside";
+import { useClickOutside } from "@/hooks/useClickOutside";
 
 const NavbarItem = ({
   href = "",

--- a/src/components/LogoutButton.tsx
+++ b/src/components/LogoutButton.tsx
@@ -3,15 +3,22 @@
 import { signOut } from "next-auth/react";
 
 import type { ClientSafeProvider } from "next-auth/react";
+import { useState } from "react";
+import { LogoutModal } from "./LogoutModal";
 
 export default function LogoutButton({ auth }: { auth?: ClientSafeProvider }) {
+  const [modalOpen, setModalOpen] = useState(false);
+
   return (
-    <button
-      type="button"
-      className="rounded-md bg-indigo-600 px-2.5 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
-      onClick={() => signOut()}
-    >
-      Logout
-    </button>
+    <>
+      <button
+        type="button"
+        className="rounded-md bg-blue-600 px-2.5 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-blue-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+        onClick={() => setModalOpen(true)}
+      >
+        Log out
+      </button>
+      <LogoutModal isOpen={modalOpen} onClose={() => setModalOpen(false)} />
+    </>
   );
 }

--- a/src/components/LogoutModal.tsx
+++ b/src/components/LogoutModal.tsx
@@ -1,0 +1,31 @@
+import { signOut } from "next-auth/react";
+import { Modal } from "./Modal";
+
+export const LogoutModal = ({
+  onClose,
+  isOpen,
+}: {
+  onClose: () => void;
+  isOpen: boolean;
+}) => (
+  <Modal isOpen={isOpen} onClose={onClose} className="flex flex-col gap-4">
+    <h1 className="font-semibold text-xl">Are you sure?</h1>
+    <div className="flex flex-row gap-4">
+      <button
+        className="bg-red-500 hover:bg-red-600 px-4 py-2 text-white rounded-md transition-colors"
+        onClick={() => {
+          signOut();
+          onClose();
+        }}
+      >
+        Log out
+      </button>
+      <button
+        className="border-neutral-200 bg-white hover:bg-neutral-100 border-2 px-4 font-white rounded-md transition-colors"
+        onClick={() => onClose()}
+      >
+        Cancel
+      </button>
+    </div>
+  </Modal>
+);

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,0 +1,50 @@
+"use client";
+import { useClickOutside } from "@/hooks/useClickOutside";
+import { HTMLAttributes, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+interface ModalProps extends HTMLAttributes<HTMLDivElement> {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export const Modal = ({
+  children,
+  isOpen = false,
+  onClose,
+  className,
+  ...rest
+}: ModalProps) => {
+  const [mounted, setMounted] = useState(false);
+
+  const modalContentRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setMounted(true);
+    return () => setMounted(false);
+  }, []);
+
+  useClickOutside(modalContentRef, onClose);
+
+  if (!isOpen) return null;
+
+  const ModalComponent = () => (
+    <div
+      className={`fixed top-0 px-4 bottom-0 left-0 right-0 flex items-center justify-center visible overflow-auto bg-neutral-700 bg-opacity-40 z-50 p-4`}
+    >
+      <div
+        ref={modalContentRef}
+        className={`max-w-full md:max-w-2/3 max-h-2/3 p-8 bg-white rounded-md ${className}`}
+        {...rest}
+      >
+        {children}
+      </div>
+    </div>
+  );
+
+  const dialogContainer = document.querySelector("#dialogs");
+
+  return mounted && dialogContainer
+    ? createPortal(<ModalComponent />, dialogContainer)
+    : null;
+};

--- a/src/hooks/useClickOutside.ts
+++ b/src/hooks/useClickOutside.ts
@@ -5,7 +5,7 @@ import { RefObject, useEffect } from "react";
  * @param {RefObject<HTMLElement> | RefObject<HTMLElement>[]} refs - A reference or an array of references to the DOM element(s) to monitor.
  * @param {() => void} callback - The function to execute when a click outside the element(s) is detected.
  */
-function useClickOutside(
+export function useClickOutside(
   refs: RefObject<HTMLElement> | RefObject<HTMLElement>[],
   callback: () => void
 ): void {
@@ -28,5 +28,3 @@ function useClickOutside(
     };
   }, [refs, callback]);
 }
-
-export default useClickOutside;


### PR DESCRIPTION
Added Modal component with the following props:

- isOpen: control whenever the modal should show or not
- onClose: is required to close the modal if the user clicks outside of it
- className: to customize the modal, e.g. its size
- children: the content passed as children will be shown inside the modal

Screenshots:
 
![firefox_ZrvtblhOMR](https://github.com/grodriguez1983/vairix-capacitation-tracker/assets/21319545/5d90d7ef-2898-4e79-ad1c-b5977506fe0c)
