### PR TITLE
fix: Login spinner & pagination issue

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -6,25 +6,31 @@ import Toast from "@/components/Toast";
 import { useSearchParams } from "next/navigation";
 import Button from "@/components/Button";
 import Card from "@/components/Card";
+import { useTransition } from "react";
 
 export default function LoginPage() {
+  const [isPending, startTransition] = useTransition();
+
   const searchParams = useSearchParams();
   const error = searchParams.get("error");
 
   let onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+
     let data = Object.fromEntries(new FormData(e.currentTarget));
     const { email, password } = data;
 
-    try {
-      await signIn("credentials", {
-        email,
-        password,
-        redirect: true,
-      });
-    } catch (error) {
-      console.log("Failed to sign in", error);
-    }
+    startTransition(async () => {
+      try {
+        await signIn("credentials", {
+          email,
+          password,
+          redirect: true,
+        });
+      } catch (error) {
+        console.log("Failed to sign in", error);
+      }
+    });
   };
 
   return (
@@ -52,7 +58,7 @@ export default function LoginPage() {
             required
           />
           <div className="flex items-center justify-end mt-4">
-            <Button label="submit" />
+            <Button pending={isPending} label="Submit" />
           </div>
         </form>
       </Card>

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from "react";
 import { useFormStatus } from "react-dom";
 import classNames from "classnames";
@@ -5,25 +7,32 @@ import { Spinner } from "./Spinner";
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   label: string;
+  pending: boolean;
 }
 
-const Button: React.FC<ButtonProps> = ({ label, className, ...props }) => {
-  const { pending } = useFormStatus();
+const Button: React.FC<ButtonProps> = ({
+  label,
+  pending,
+  className,
+  ...props
+}) => {
+  const { pending: formPending } = useFormStatus();
+  const isPending = formPending || pending;
 
   return (
     <button
       className={classNames(
         "px-4 py-1 font-light h-10 tracking-wider transition-all rounded",
         {
-          "text-white bg-gray-900 hover:bg-gray-800": !pending,
-          "text-gray-500 bg-gray-300": pending,
+          "text-white bg-gray-900 hover:bg-gray-800": !isPending,
+          "text-gray-500 bg-gray-300": isPending,
         },
         className
       )}
-      disabled={pending}
+      disabled={isPending}
       {...props}
     >
-      {!pending ? label : <Spinner />}
+      {!isPending ? label : <Spinner />}
     </button>
   );
 };

--- a/src/components/Office/OfficesTable.tsx
+++ b/src/components/Office/OfficesTable.tsx
@@ -6,6 +6,7 @@ import { Actions } from "../Table/Actions";
 import { Table } from "../Table";
 import { UpdateForm } from "./UpdateForm";
 import { DeleteForm } from "./DeleteForm";
+import { Spinner } from "../Spinner";
 
 export const OfficesTable = ({
   data,
@@ -45,6 +46,7 @@ export const OfficesTable = ({
 
   return (
     <Table
+      emptyMessage={<Spinner className="border-gray-600 mt-10 h-10 w-10" />}
       columns={columns}
       data={data.map((office) => ({
         ...office,

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -1,22 +1,41 @@
 "use client";
-import { usePathname, useSearchParams, useRouter } from "next/navigation";
 import { ITEMS_PER_PAGE } from "@/lib/constants";
+import { usePathname, useSearchParams, useRouter } from "next/navigation";
+import { useEffect, useMemo } from "react";
 
 const Pagination = ({ count }: { count: number }) => {
   const searchParams = useSearchParams();
   const { replace } = useRouter();
   const pathname = usePathname();
 
-  const page = searchParams.get("page") || "1";
-  const params = new URLSearchParams(searchParams);
+  const page = parseInt(searchParams.get("page") || "1");
+  const params = useMemo(
+    () => new URLSearchParams(searchParams),
+    [searchParams]
+  );
 
-  const hasPrev = ITEMS_PER_PAGE * (parseInt(page) - 1) > 0;
-  const hasNext = ITEMS_PER_PAGE * (parseInt(page) - 1) + ITEMS_PER_PAGE < count;
+  const hasPrev = ITEMS_PER_PAGE * (page - 1) > 0;
+  const hasNext = ITEMS_PER_PAGE * (page - 1) + ITEMS_PER_PAGE < count;
+
+  // useEffect to handle whenever the user is on an invalid page
+  useEffect(() => {
+    if (page <= 0) {
+      params.set("page", "1");
+      replace(`${pathname}?${params}`);
+    }
+
+    const lastAvailablePage = Math.ceil(count / ITEMS_PER_PAGE);
+
+    if (page > lastAvailablePage) {
+      params.set("page", String(lastAvailablePage));
+      replace(`${pathname}?${params}`);
+    }
+  }, [count, page, params, pathname, replace]);
 
   const handleChangePage = (type: string) => {
     type === "prev"
-      ? params.set("page", String(parseInt(page) - 1))
-      : params.set("page", String(parseInt(page) + 1));
+      ? params.set("page", String(page - 1))
+      : params.set("page", String(page + 1));
     replace(`${pathname}?${params}`);
   };
 

--- a/src/components/Spinner.tsx
+++ b/src/components/Spinner.tsx
@@ -5,7 +5,9 @@ export const Spinner = ({
   ...props
 }: HTMLAttributes<HTMLDivElement>) => (
   <div
-    className={`border-t-transparent border-solid animate-spin rounded-full border-white border-4 h-6 w-6 ${className}`}
+    className={`border-t-transparent border-solid animate-spin rounded-full border-4 ${
+      className ? className : "border-white h-6 w-6"
+    }`}
     {...props}
   />
 );

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -33,10 +33,6 @@ export const Table: React.FC<TableProps> = ({
   pagination,
   emptyMessage = "No data available",
 }) => {
-  if (!data.length) {
-    return <div>{emptyMessage}</div>;
-  }
-
   const TableComponent = () => (
     <table className="w-full">
       <thead>
@@ -75,8 +71,8 @@ export const Table: React.FC<TableProps> = ({
   );
 
   return (
-    <div className="w-full shadow rounded-lg overflow-x-auto">
-      <TableComponent />
+    <div className="w-full flex flex-col items-center shadow rounded-lg overflow-x-auto">
+      {data.length ? <TableComponent /> : <div>{emptyMessage}</div>}
       {pagination}
     </div>
   );


### PR DESCRIPTION
Changes:

- Now the Button component accepts an alternative `pending` prop to make it more versatile
- Now if you head to an unavailable table page the `Pagination` component will redirect you to the nearest available page
- Now the Login page handles the pending status by using the new `useTransition` hook.

Preview:

|  Login  | Table  |
|---|---|
|  ![firefox_mKsIW2PxEw](https://github.com/grodriguez1983/vairix-capacitation-tracker/assets/21319545/4949891c-a708-4697-8af1-3df0dbb8cf8e) |  ![firefox_9eAWfeezuY](https://github.com/grodriguez1983/vairix-capacitation-tracker/assets/21319545/09897ce3-a57b-4687-9661-23d42eca4c3f)|
