### PR TITLE
feat: added not found fallback page

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,10 @@
+import { checkUserRole } from "@/lib/auth";
+import { redirect } from "next/navigation";
+
+export default async function NotFound() {
+  const role = await checkUserRole();
+
+  if (role === null) redirect("/login");
+
+  redirect("/dashboard");
+}


### PR DESCRIPTION
- [x] Added `not-found` page that redirects you based if you are logged or not

examples:

|  Before | After |
|---|---|
| <img width="565" alt="firefox_JCrVcmToyN" src="https://github.com/grodriguez1983/vairix-capacitation-tracker/assets/21319545/b018825b-2078-4e62-a83c-17767d398670"> |![firefox_u89fVUAxbt](https://github.com/grodriguez1983/vairix-capacitation-tracker/assets/21319545/e7d49e86-5391-44a2-9dbf-0054e8e5439b) | 
<img width="567" alt="firefox_PwZjg7FJkY" src="https://github.com/grodriguez1983/vairix-capacitation-tracker/assets/21319545/36b45302-61fe-44c2-88c7-45d8b03095de">|![firefox_Me0On1H07v](https://github.com/grodriguez1983/vairix-capacitation-tracker/assets/21319545/23c91329-a48e-429b-a1d2-bcb0493c3a8a) |



