### PR TITLE
feat: added Office Calendar page

### DIFF
--- a/src/app/dashboard/@user/calendar/[officeId]/page.tsx
+++ b/src/app/dashboard/@user/calendar/[officeId]/page.tsx
@@ -2,7 +2,7 @@ import { OfficeCalendar } from "@/components/Calendar/OfficeCalendar";
 import { fetchOffice } from "@/lib/data";
 import { redirect } from "next/navigation";
 
-export default async function CalendarPage({
+export default async function OfficeCalendarPage({
   params: { officeId },
 }: {
   params: { officeId: string };

--- a/src/app/dashboard/@user/calendar/[officeId]/page.tsx
+++ b/src/app/dashboard/@user/calendar/[officeId]/page.tsx
@@ -1,0 +1,15 @@
+import { OfficeCalendar } from "@/components/Calendar/OfficeCalendar";
+import { fetchOffice } from "@/lib/data";
+import { redirect } from "next/navigation";
+
+export default async function CalendarPage({
+  params: { officeId },
+}: {
+  params: { officeId: string };
+}) {
+  const office = await fetchOffice(officeId);
+
+  if (!office) return redirect("/dashboard/offices");
+
+  return <OfficeCalendar office={office} />;
+}

--- a/src/components/Calendar/OfficeCalendar.tsx
+++ b/src/components/Calendar/OfficeCalendar.tsx
@@ -50,16 +50,14 @@ export const OfficeCalendar = ({ office }: { office: Office }) => {
   };
 
   return (
-    <>
-      <CustomCalendar
-        events={office?.events || []}
-        onView={onView}
-        onSelectSlot={onSelectSlot}
-        onSelectEvent={onSelectEvent}
-        onEventResize={onEventResize}
-        onEventDrop={onEventDrop}
-        view={calendarView}
-      />
-    </>
+    <CustomCalendar
+      events={office?.events || []}
+      onView={onView}
+      onSelectSlot={onSelectSlot}
+      onSelectEvent={onSelectEvent}
+      onEventResize={onEventResize}
+      onEventDrop={onEventDrop}
+      view={calendarView}
+    />
   );
 };

--- a/src/components/Calendar/OfficeCalendar.tsx
+++ b/src/components/Calendar/OfficeCalendar.tsx
@@ -51,7 +51,7 @@ export const OfficeCalendar = ({ office }: { office: Office }) => {
 
   return (
     <CustomCalendar
-      events={office?.events || []}
+      events={events}
       onView={onView}
       onSelectSlot={onSelectSlot}
       onSelectEvent={onSelectEvent}

--- a/src/components/Calendar/OfficeCalendar.tsx
+++ b/src/components/Calendar/OfficeCalendar.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { CustomCalendar } from "@/components/Calendar";
+import { Office } from "@/types/offices";
+import { useCallback, useMemo, useState } from "react";
+import { Event, SlotInfo, View } from "react-big-calendar";
+import { withDragAndDropProps } from "react-big-calendar/lib/addons/dragAndDrop";
+
+export const OfficeCalendar = ({ office }: { office: Office }) => {
+  const events = useMemo(() => office.events || [], [office.events]);
+  const [calendarView, setCalendarView] = useState<View>("week");
+
+  const isOverlapping = useCallback(
+    (start: Date, end: Date, name: string) => {
+      let overlap = false;
+      events.forEach((event) => {
+        if (event.name === name) return false;
+        if (
+          (event.start && event.start > start && event.start < end) ||
+          (event.end && event.end > start && event.end < end)
+        ) {
+          overlap = true;
+        }
+      });
+      return overlap;
+    },
+    [events]
+  );
+
+  const onView = useCallback((view: View) => {
+    setCalendarView(view);
+  }, []);
+
+  const onSelectSlot = useCallback((props: SlotInfo) => {
+    // TODO
+  }, []);
+
+  const onSelectEvent = useCallback((event: Event) => {
+    // TODO
+  }, []);
+
+  const onEventResize: withDragAndDropProps<Event>["onEventResize"] = (
+    data
+  ) => {
+    // TODO
+  };
+
+  const onEventDrop: withDragAndDropProps<Event>["onEventDrop"] = (data) => {
+    // TODO
+  };
+
+  return (
+    <>
+      <CustomCalendar
+        events={office?.events || []}
+        onView={onView}
+        onSelectSlot={onSelectSlot}
+        onSelectEvent={onSelectEvent}
+        onEventResize={onEventResize}
+        onEventDrop={onEventDrop}
+        view={calendarView}
+      />
+    </>
+  );
+};

--- a/src/components/Calendar/index.tsx
+++ b/src/components/Calendar/index.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import {
+  View,
+  Event,
+  SlotInfo,
+  dateFnsLocalizer,
+  Calendar,
+} from "react-big-calendar";
+import withDragAndDrop, {
+  withDragAndDropProps,
+} from "react-big-calendar/lib/addons/dragAndDrop";
+import Card from "../Card";
+import { enUS } from "date-fns/locale";
+import { addHours, startOfHour } from "date-fns";
+import format from "date-fns/format";
+import parse from "date-fns/parse";
+import startOfWeek from "date-fns/startOfWeek";
+import getDay from "date-fns/getDay";
+
+import "react-big-calendar/lib/addons/dragAndDrop/styles.css";
+import "react-big-calendar/lib/css/react-big-calendar.css";
+
+interface CalendarProps {
+  onNavigate?: (newDate: Date) => void;
+  onView?: (view: View) => void;
+  onSelectSlot?: (slotInfo: SlotInfo) => void;
+  onSelectEvent?: (event: Event) => void;
+  onEventResize?: withDragAndDropProps<Event>["onEventResize"];
+  onEventDrop?: withDragAndDropProps<Event>["onEventDrop"];
+  events: Event[];
+  view?: View;
+}
+
+export const CustomCalendar = ({
+  onNavigate,
+  onView,
+  onSelectSlot,
+  onSelectEvent,
+  onEventResize,
+  onEventDrop,
+  events,
+  view = "week",
+}: CalendarProps) => {
+  const [date, setDate] = useState(new Date());
+
+  const handleNavigate = useCallback(
+    (newDate: Date) => {
+      setDate(newDate);
+      onNavigate && onNavigate(newDate);
+    },
+    [onNavigate]
+  );
+
+  return (
+    <Card className="mx-6">
+      <DnDCalendar
+        defaultView={view}
+        view={view}
+        date={date}
+        onView={onView}
+        events={events}
+        localizer={localizer}
+        onEventDrop={onEventDrop}
+        onEventResize={onEventResize}
+        onSelectSlot={onSelectSlot}
+        resizable
+        selectable
+        onNavigate={handleNavigate}
+        onSelectEvent={onSelectEvent}
+        style={{ height: "100vh", color: "rgb(37 99 235)" }}
+      />
+    </Card>
+  );
+};
+
+const locales = {
+  "en-US": enUS,
+};
+const endOfHour = (date: Date): Date => addHours(startOfHour(date), 1);
+const now = new Date();
+const start = endOfHour(now);
+const end = addHours(start, 2);
+
+// The types here are `object`. Strongly consider making them better as removing `locales` caused a fatal error
+const localizer = dateFnsLocalizer({
+  format,
+  parse,
+  startOfWeek,
+  getDay,
+  locales,
+});
+const DnDCalendar = withDragAndDrop(Calendar);

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -52,7 +52,7 @@ export const fetchOffices = async (
 export const fetchOffice = async (id: string): Promise<Office | null> => {
   const userRole = await checkUserRole();
 
-  if (userRole !== "admin") {
+  if (userRole === null) {
     return null;
   }
 
@@ -60,6 +60,9 @@ export const fetchOffice = async (id: string): Promise<Office | null> => {
     const office = await prisma.office.findUnique({
       where: {
         id: id,
+      },
+      include: {
+        events: true,
       },
     });
 

--- a/src/types/offices.ts
+++ b/src/types/offices.ts
@@ -3,11 +3,21 @@ export enum OfficeType {
   Medium = "medium",
   Large = "large",
 }
-  export interface Office {
+export interface Office {
   id: string;
   name: string;
   createdAt: Date;
   type: OfficeType;
+  events?: Event[];
+}
+
+export interface Event {
+  id: string;
+  name: string;
+  createdAt: Date;
+  start: Date;
+  end: Date;
+  officeId: string;
 }
 
 export interface OfficesResponse {


### PR DESCRIPTION
- [x] Added `/calendar/officeId` page
- [x] Added `OfficeCalendar` component, it recieves the office as prop
- [x] Added a generic `Calendar` component to build specific calendars easier 

Screenshots:

![image](https://github.com/grodriguez1983/vairix-capacitation-tracker/assets/21319545/228d17bb-1d7e-4bda-92f2-24765b63e441)
